### PR TITLE
libRuler fix

### DIFF
--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -2911,23 +2911,23 @@ Hooks.on('controlDrawing', (drawing, control) => {
         MonksActiveTiles.controlEntity(drawing);
 });
 
-Hooks.on('libRulerReady', () => {
-    Ruler.prototype.animateToken = async function (token, ray, dx, dy, segment_num) {
-        log(`Animating token for segment_num ${segment_num}`);
-
-        // Adjust the ray based on token size
-        const dest = canvas.grid.getTopLeft(ray.B.x, ray.B.y);
-        const path = new Ray({ x: token.data.x, y: token.data.y }, { x: dest[0] + dx, y: dest[1] + dy });
-
-        // Commit the movement and update the final resolved destination coordinates
-        const priorDest = duplicate(path.B);
-        await token.document.update(path.B);
-        path.B.x = token.data.x;
-        path.B.y = token.data.y;
-
-        // Update the path which may have changed during the update, and animate it
-        await token.animateMovement(path);
-
-        return priorDest;
-    }
-});
+// Hooks.on('libRulerReady', () => {
+//     Ruler.prototype.animateToken = async function (token, ray, dx, dy, segment_num) {
+//         log(`Animating token for segment_num ${segment_num}`);
+// 
+//         // Adjust the ray based on token size
+//         const dest = canvas.grid.getTopLeft(ray.B.x, ray.B.y);
+//         const path = new Ray({ x: token.data.x, y: token.data.y }, { x: dest[0] + dx, y: dest[1] + dy });
+// 
+//         // Commit the movement and update the final resolved destination coordinates
+//         const priorDest = duplicate(path.B);
+//         await token.document.update(path.B);
+//         path.B.x = token.data.x;
+//         path.B.y = token.data.y;
+// 
+//         // Update the path which may have changed during the update, and animate it
+//         await token.animateMovement(path);
+// 
+//         return priorDest;
+//     }
+// });

--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -2911,23 +2911,6 @@ Hooks.on('controlDrawing', (drawing, control) => {
         MonksActiveTiles.controlEntity(drawing);
 });
 
-// Hooks.on('libRulerReady', () => {
-//     Ruler.prototype.animateToken = async function (token, ray, dx, dy, segment_num) {
-//         log(`Animating token for segment_num ${segment_num}`);
-// 
-//         // Adjust the ray based on token size
-//         const dest = canvas.grid.getTopLeft(ray.B.x, ray.B.y);
-//         const path = new Ray({ x: token.data.x, y: token.data.y }, { x: dest[0] + dx, y: dest[1] + dy });
-// 
-//         // Commit the movement and update the final resolved destination coordinates
-//         const priorDest = duplicate(path.B);
-//         await token.document.update(path.B);
-//         path.B.x = token.data.x;
-//         path.B.y = token.data.y;
-// 
-//         // Update the path which may have changed during the update, and animate it
-//         await token.animateMovement(path);
-// 
-//         return priorDest;
-//     }
-// });
+Hooks.on('libRulerReady', () => {
+
+});


### PR DESCRIPTION
Hi!

I saw that libWrapper was complaining about Monk's Active Tiles overwriting `Ruler.prototype.animateToken` and a conflict with Elevation Ruler.  I took a look, and I see that you are overwriting that method even when libRuler is active. From what I can tell, the code you are using is exactly identical to libRuler's version of `animateToken`, so overwriting it is no longer necessary.  

I am guessing this might be leftover code from an older version of libRuler that either didn't overwrite animateToken or overwrote it in a way that was problematic for your code. I recall you opened [an issue](https://github.com/caewok/fvtt-lib-ruler/issues/3) about how `priorDest` was being set, since resolved. 

Thanks!