### PR TITLE
Bugfix: teleporting tokens loses temporary information

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,8 +1,8 @@
 {
   "name": "monks-active-tiles",
-  "title": "Monk's Active Tile Triggers",
+  "title": "Monk's Active Tile Triggers - StreyVersion",
   "description": "Want to teleport, or open doors, or hide characters, or display a message, or play a sound, or change a token's elevation when a token walks over a tile... now you can",
-	"version": "1.0.43",
+	"version": "1.0.44",
 	"minimumCoreVersion": "9",
 	"compatibleCoreVersion": "9.238",
 	"author": "IronMonk",

--- a/module.json
+++ b/module.json
@@ -49,7 +49,7 @@
     "css/monks-active-tiles.css"
   ],
   "url": "https://github.com/Streyder/monks-active-tiles",
-  "download": "https://github.com/ironmonk88/monks-active-tiles/archive/1.0.43.zip",
+  "download": "https://github.com/Streyder/monks-active-tiles/archive/refs/tags/1.0.44.zip",
   "manifest": "https://raw.githubusercontent.com/Streyder/monks-active-tiles/main/module.json",
   "bugs": "https://github.com/ironmonk88/monks-active-tiles/issues",
   "allowBugReporter": true

--- a/module.json
+++ b/module.json
@@ -1,5 +1,5 @@
 {
-  "name": "monks-active-tiles",
+  "name": "monks-active-tiles-strey",
   "title": "Monk's Active Tile Triggers - StreyVersion",
   "description": "Want to teleport, or open doors, or hide characters, or display a message, or play a sound, or change a token's elevation when a token walks over a tile... now you can",
 	"version": "1.0.44",
@@ -48,9 +48,9 @@
   "styles": [
     "css/monks-active-tiles.css"
   ],
-  "url": "https://github.com/ironmonk88/monks-active-tiles",
+  "url": "https://github.com/Streyder/monks-active-tiles",
   "download": "https://github.com/ironmonk88/monks-active-tiles/archive/1.0.43.zip",
-  "manifest": "https://github.com/ironmonk88/monks-active-tiles/releases/latest/download/module.json",
+  "manifest": "https://raw.githubusercontent.com/Streyder/monks-active-tiles/main/module.json",
   "bugs": "https://github.com/ironmonk88/monks-active-tiles/issues",
   "allowBugReporter": true
 }

--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -309,13 +309,14 @@ export class MonksActiveTiles {
                         }
 
                         if (newtoken) {
-                            await newtoken.update({ x: newPos.x, y: newPos.y, hidden: tokendoc.data.hidden }, { bypass: true, animate: false });
+                            await newtoken.delete();
                         }
-                        else {
-                            const td = await tokendoc.actor.getTokenData({ x: newPos.x, y: newPos.y });
-                            const cls = getDocumentClass("Token");
-                            newtoken = await cls.create(td, { parent: scene });
-                        }
+                        
+                        const td = tokendoc.toObject();
+                        const cls = getDocumentClass("Token");
+                        newtoken = await cls.create(td, { parent: scene });
+                        await newtoken.update({ x: newPos.x, y: newPos.y }, { bypass: true, animate: false });
+                        
                         let oldhidden = tokendoc.data.hidden;
                         if (action.data.deletesource)
                             tokendoc.delete();


### PR DESCRIPTION
when a token got teleported, the teleport did not duplicate the token data but would create a new token based on the actors prototype token. This causes loss of changes made to the current token, which are not reflected in the prototype token. Examples: Light settings, token orientation.