### PR TITLE
Use macro.execute for advanced-macro macro calls

### DIFF
--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -465,7 +465,7 @@ export class MonksActiveTiles {
 
         if (runasgm || userid == game.user.id) {
             if (game.modules.get("advanced-macros")?.active || game.modules.get("furnace")?.active)
-                return await (macro.type == 'script' ? macro.callScriptFunction(context) : macro.execute(args));
+                return await (macro.type == 'script' ? macro.execute(context) : macro.execute(args));
             else
                 return await (macro.type == 'script' ? MonksActiveTiles._execute.call(macro, context) : macro.execute(args));
         } else {
@@ -490,7 +490,7 @@ export class MonksActiveTiles {
         if (game.modules.get("advanced-macros")?.active || game.modules.get("furnace")?.active) {
             if (getProperty(macro, "flags.advanced-macros.runAsGM") || getProperty(macro, "flags.furnace.runAsGM") || userid == game.user.id) {
                 //execute the macro if it's set to run as GM or it was the GM that actually moved the token.
-                return await macro.callScriptFunction(context);
+                return await macro.execute(context);
             } else {
                 //this one needs to be run as the player, so send it back
                 MonksActiveTiles.emit('runmacro', {
@@ -1949,7 +1949,7 @@ export class MonksActiveTiles {
                     };
 
                     let results = (game.modules.get("advanced-macros")?.active || game.modules.get("furnace")?.active ?
-                        await (macro.type == 'script' ? macro.callScriptFunction(context) : macro.execute(data.args)) :
+                        await (macro.type == 'script' ? macro.execute(context) : macro.execute(data.args)) :
                         await MonksActiveTiles._execute.call(macro, context));
                     MonksActiveTiles.emit("returnmacro", { _id: data._id, tileid: data?.tileid, results: results });
                 }


### PR DESCRIPTION
advanced-macro has removed callScriptFunction for v10.273 and instead use macro.execute directly now.

![image](https://user-images.githubusercontent.com/15907070/189258822-a023d908-5136-4159-b1ed-4235dfc177cc.png)
This is advanced-macro internal code, where they replaced callScriptFunction with that function. You can also see that the commit which removes callScriptFunction, registers execute as its replacement.