### PR TITLE
A tentative to add the trigger configuration on the Notes (just like the doors)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
   "MonksActiveTiles.PlayerTokens": "Player Tokens",
   "MonksActiveTiles.CurrentLocation": "Current Location",
   "MonksActiveTiles.WithinTile": "Tokens within Tile",
+  "MonksActiveTiles.WithinNote": "Tiles under Note",
   "MonksActiveTiles.WithinWall": "Tiles under Door",
   "MonksActiveTiles.CurrentCollection": "Current {collection}",
   "MonksActiveTiles.Origin": "Original Destination",
@@ -278,6 +279,14 @@
   "MonksActiveTiles.audiotype.all": "Ambient Sounds",
   "MonksActiveTiles.audiotype.tile": "Tile Sounds",
 
+  "MonksActiveTiles.label.OnLeftClick": "On Left Click",
+  "MonksActiveTiles.label.OnRightClick": "On Right Click",
+  "MonksActiveTiles.label.OnOpenDoor": "On Open Door",
+  "MonksActiveTiles.label.OnCloseDoor": "On Close Door",
+  "MonksActiveTiles.label.OnLockDoor": "On Lock Door",
+  "MonksActiveTiles.label.OnCheckLock": "On Check Lock",
+  "MonksActiveTiles.label.OnSecretDoor": "On Secret Door",
+
   "MonksActiveTiles.state.open": "Open",
   "MonksActiveTiles.state.closed": "Closed",
   "MonksActiveTiles.state.locked": "Locked",
@@ -389,6 +398,8 @@
   "MonksActiveTiles.use-core-macro.hint": "Core macro execution doesn't pass all the information available so Active Tiles handles executing macros.  Turn this back on if it's causing issues.'",
   "MonksActiveTiles.drop-item.name": "Drop Item on Canvas",
   "MonksActiveTiles.drop-item.hint": "Allow items dropped on the canvas to be created as Active Tiles",
+  "MonksActiveTiles.allow-note.name": "Note Triggers",
+  "MonksActiveTiles.allow-note.hint": "Allow Notes to trigger Tiles",
   "MonksActiveTiles.allow-door.name": "Door Triggers",
   "MonksActiveTiles.allow-door.hint": "Allow Doors to trigger Tiles",
   "MonksActiveTiles.teleport-wash.name": "Show Teleport Wash",
@@ -401,6 +412,8 @@
   "MonksActiveTiles.show-help.hint": "Show helpful action hints for fields that have complex values",
   "MonksActiveTiles.prevent-when-paused.name": "Prevent when paused",
   "MonksActiveTiles.prevent-when-paused.hint": "Prevent players from triggering Tiles when the game is paused.",
+  "MonksActiveTiles.allow-note-passthrough.name": "Allow Note Click-through",
+  "MonksActiveTiles.allow-note-passthrough.hint": "Allow Tiles underneath a note to still be triggered if the note is clicked on",
   "MonksActiveTiles.allow-door-passthrough.name": "Allow Door Click-through",
   "MonksActiveTiles.allow-door-passthrough.hint": "Allow Tiles underneath a door to still be triggered if the door is clicked on"
 }

--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -2132,11 +2132,6 @@ export class MonksActiveTiles {
             return wrapped(...args);
         }
 
-        let rightClick = async function (wrapped, ...args) {
-            MonksActiveTiles.controlEntity(this);
-            return wrapped(...args);
-        }
-
         let leftClickOnTokenLayer = async function (wrapped, ...args) {
             if(setting("allow-note")) {
                 const notes = retrievePlaceablesWithXY(this,canvas?.notes?.placeables);
@@ -2197,15 +2192,6 @@ export class MonksActiveTiles {
             const oldOnClickLeft = Note.prototype._onClickLeft;
             Note.prototype._onClickLeft = function (event) {
                 return leftClick.call(this, oldOnClickLeft.bind(this), ...arguments);
-            }
-        }
-
-        if (game.modules.get("lib-wrapper")?.active) {
-            libWrapper.register("monks-active-tiles", "Note.prototype._onClickRight", rightClick, "WRAPPER");
-        } else {
-            const oldOnClickRight = Note.prototype._onClickRight;
-            Note.prototype._onClickRight = function (event) {
-                return rightClick.call(this, oldOnClickRight.bind(this), ...arguments);
             }
         }
 

--- a/settings.js
+++ b/settings.js
@@ -41,6 +41,15 @@ export const registerSettings = function () {
 		type: Boolean,
 	});
 
+  game.settings.register(modulename, "allow-note", {
+		name: i18n("MonksActiveTiles.allow-note.name"),
+		hint: i18n("MonksActiveTiles.allow-note.hint"),
+		scope: "world",
+		config: true,
+		default: false,
+		type: Boolean,
+	});
+
 	game.settings.register(modulename, "allow-door", {
 		name: i18n("MonksActiveTiles.allow-door.name"),
 		hint: i18n("MonksActiveTiles.allow-door.hint"),
@@ -80,6 +89,15 @@ export const registerSettings = function () {
 	game.settings.register(modulename, "prevent-when-paused", {
 		name: i18n("MonksActiveTiles.prevent-when-paused.name"),
 		hint: i18n("MonksActiveTiles.prevent-when-paused.hint"),
+		scope: "world",
+		config: true,
+		default: true,
+		type: Boolean,
+	});
+
+  game.settings.register(modulename, "allow-note-passthrough", {
+		name: i18n("MonksActiveTiles.allow-note-passthrough.name"),
+		hint: i18n("MonksActiveTiles.allow-note-passthrough.hint"),
 		scope: "world",
 		config: true,
 		default: true,

--- a/templates/note-config.html
+++ b/templates/note-config.html
@@ -12,36 +12,15 @@
 </div>
 
 <div class="form-group">
-    <label>{{localize "MonksActiveTiles.label.OnOpenDoor"}}</label>
+    <label>{{localize "MonksActiveTiles.label.OnLeftClick"}}</label>
     <div class="form-fields">
-        <input type="checkbox" name="flags.monks-active-tiles.open" {{checked open}} />
+        <input type="checkbox" name="flags.monks-active-tiles.leftclick" {{checked leftclick}} />
     </div>
 </div>
 
 <div class="form-group">
-    <label>{{localize "MonksActiveTiles.label.OnCloseDoor"}}</label>
+    <label>{{localize "MonksActiveTiles.label.OnRightClick"}}</label>
     <div class="form-fields">
-        <input type="checkbox" name="flags.monks-active-tiles.close" {{checked close}} />
-    </div>
-</div>
-
-<div class="form-group">
-    <label>{{localize "MonksActiveTiles.label.OnLockDoor"}}</label>
-    <div class="form-fields">
-        <input type="checkbox" name="flags.monks-active-tiles.lock" {{checked lock}} />
-    </div>
-</div>
-
-<div class="form-group">
-    <label>{{localize "MonksActiveTiles.label.OnCheckLock"}}</label>
-    <div class="form-fields">
-        <input type="checkbox" name="flags.monks-active-tiles.checklock" {{checked checklock}} />
-    </div>
-</div>
-
-<div class="form-group">
-    <label>{{localize "MonksActiveTiles.label.OnSecretDoor"}}</label>
-    <div class="form-fields">
-        <input type="checkbox" name="flags.monks-active-tiles.secret" {{checked secret}} />
+        <input type="checkbox" name="flags.monks-active-tiles.rightclick" {{checked rightclick}} />
     </div>
 </div>


### PR DESCRIPTION
I tried integrating triggers on note configurations because I prefer them to tiles in some contexts, but encountered several problems.

The first problem I encountered is that the `Note.prototype._onClickLeft` `Note.prototype._onClickRight` wrapper listeners seem to work only when you are on the `NoteLayer` and not the `TokenLayer` (I don't know if this is correct or not maybe i should open a issue on the foundryvtt project ?).

To remedy the issue once the note is set up with the trigger with the same mechanism set up for doors, I capture the coordinates of the click on the canvas while we are on the `TokenLayer` and check if the click is within a note.

I am not sure if the code I have written is the best way to integrate this functionality , so any comments are welcome.
