### PR TITLE
fix off target teleportation between scenes with different dimensions.

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -408,6 +408,11 @@ export class ActionManager {
                             let scene = game.scenes.get(dest.scene);
                             let newtoken = (tokendoc.actor?.id && tokendoc.actorLink ? scene.tokens.find(t => { return t.actor?.id == tokendoc.actor?.id }) : null);
 
+                            // -flo- ludifu
+                            // recalculate tokenWidth and tokenHeight for the new scene. This is required because the new scene may have different dimensions.
+                            tokenWidth = ((scene.dimensions.size * Math.abs(tokendoc.width)) / 2);
+                            tokenHeight = ((scene.dimensions.size * Math.abs(tokendoc.height)) / 2);
+
                             //find a vacant spot
                             if (action.data.avoidtokens)
                                 newPos = MonksActiveTiles.findVacantSpot(newPos, tokendoc, scene, newTokens, dest, action.data.remotesnap);
@@ -416,6 +421,13 @@ export class ActionManager {
                             newPos.y -= tokenHeight;
 
                             if (action.data.remotesnap) {
+                                // -flo- ludifu
+                                // use dimension of the new scene instead of tokendoc.parent (old scene). Reuqired because the new scene's dimensions may be different from the old one's.
+                                newPos.x = newPos.x.toNearest(scene.dimensions.size);
+                                newPos.x = newPos.x.toNearest(scene.dimensions.size);
+                                //newPos.y = newPos.y.toNearest(tokendoc.parent.dimensions.size);
+                                //newPos.y = newPos.y.toNearest(tokendoc.parent.dimensions.size);
+
                                 newPos.x = newPos.x.toNearest(tokendoc.parent.dimensions.size);
                                 newPos.y = newPos.y.toNearest(tokendoc.parent.dimensions.size);
                             }

--- a/actions.js
+++ b/actions.js
@@ -427,9 +427,6 @@ export class ActionManager {
                                 newPos.x = newPos.x.toNearest(scene.dimensions.size);
                                 //newPos.y = newPos.y.toNearest(tokendoc.parent.dimensions.size);
                                 //newPos.y = newPos.y.toNearest(tokendoc.parent.dimensions.size);
-
-                                newPos.x = newPos.x.toNearest(tokendoc.parent.dimensions.size);
-                                newPos.y = newPos.y.toNearest(tokendoc.parent.dimensions.size);
                             }
 
                             let td = mergeObject(await tokendoc.toObject(), { x: newPos.x, y: newPos.y, 'flags.monks-active-tiles.teleporting': true, 'flags.monks-active-tiles.current': true });


### PR DESCRIPTION
When a token's target position is calculated the previous scene's dimensions are used which will result in a wrong position when the scenes have different dimensions.
The corrected code works for target tiles and the center and random target positions with and without snap to grid. I didnÄt test other constellations, but tokendoc.parent (referring to the old scene) is not used further down, so I guess the rest should work as well.