### PR TITLE
Fix for token rotation bug

### DIFF
--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -1553,14 +1553,23 @@ export class MonksActiveTiles {
             animations["movement"] = attributes;
         //if (positionChange)
          //   object.position.set(from.x ?? to.x, from.y ?? to.y);
-        let dr = to.rotation - from.rotation;
-        if (!isNaN(dr) && dr !== 0) {
-            let r = to.rotation;
-            if (dr > 180) r -= 360;
-            if (dr < -180) r += 360;
-            dr = r - from.rotation;
-            animations["rotation"] = [{ attribute: "rotation", from: (from.rotation * (Math.PI / 180)), to: (r * (Math.PI / 180)), parent: object }]; // Do not use Math.toRadians because that will normalise the number
+
+
+        let whence = from.rotation % 360;  // This fix suggests a problem elsewhere
+        let dr     = to.rotation - whence;
+
+        if (dr) {
+            const DEG_TO_RAD = Math.PI / 180;
+            let r = (dr + 540) % 360 - 180;
+
+            animations["rotation"] = [{
+                attribute: "rotation",
+                from:      whence       * DEG_TO_RAD,
+                to:        (whence + r) * DEG_TO_RAD,
+                parent:    object
+            }];
         }
+
         let hasAlpha = false;
         if (from.alpha != undefined && to.alpha != undefined && from.alpha != to.alpha) {
             animations["alpha"] = [{ parent: object, attribute: 'alpha', from: from.alpha, to: to.alpha }];


### PR DESCRIPTION
### Description
This patch addresses a rotation bug in animateEntity.

### Issue

Seems to be the same as this:
https://github.com/ironmonk88/monks-active-tiles/issues/499

This improves the behavior, but doesn't fix the point about 360-degree
rotation.

### Changes Made
- Simplify the logic using modulo arithmetic
- Simplify the code generally, for legibility
- Suppress bug by using (from.rotation % 360) rather than (from.rotation)

### Testing
Done by hand.  Bugs went away, and I noticed no new ones.

### Details

The main problem is that at certain points, when rotation goes to 0,
the token rotates the wrong way.

This seems to be associated with stored rotation values higher than
360 degrees and lower than -360 degrees.  So, for instance, if you
rotate clockwise to 288 and then to 0, it works as expected the first
time.  But if you rotate clockwise to 288 again, and again to 0, the rotation
happens counter-clockwise, despite that you gave a positive rotation value.

Simplifying the logic with modular artihmetic seems to have fixed the bug
for counter-clockwise rotation.  Then, using (from.rotation % 360) rather
than (from.rotation) gives what seems to be correct behavior for clockwise
rotation.

Clearly the system is elsewhere keeping track of absolute, rather than modular,
rotation.  So, one full clockwise rotation stores 360, another stores 720, and
so on. I don't know whether this is desirable, but if it isn't, this problem
should be fixed at its source.  If it is desirable, then we need to compensate
for it here.
