### PR TITLE
Use foundry.utils to reference lineSegmentIntersects

### DIFF
--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -1985,7 +1985,7 @@ export class MonksActiveTiles {
 
         let wallCollide = function (ray) {
             for (let wall of scene.walls) {
-                if (lineSegmentIntersects(ray.A, ray.B, { x: wall.c[0], y: wall.c[1] }, { x: wall.c[2], y: wall.c[3] }))
+                if (foundry.utils.lineSegmentIntersects(ray.A, ray.B, { x: wall.c[0], y: wall.c[1] }, { x: wall.c[2], y: wall.c[3] }))
                     return true;
             }
             return false


### PR DESCRIPTION
Inside wallCollide, lineSegmentIntersects was being called implicitly using globalThis, which triggers a warning in Foundry. This change just updates the function call to use foundry.utils.lineSegmentIntersects explicitly.

There are already several places that call the function with the foundry object, but this one spot in wallCollide was still referencing it as a global.

I noticed the issue because teleports were unusually slow on our instance, and the host's browser would hang during teleports — especially if the whole party tried to teleport at once. After some profiling, I found that Foundry's logCompatibilityWarning method was getting triggered thousands of times. Even though the once functionality prevents the warning from spamming the console, the overhead of invoking logCompatibilityWarning is surprisingly high. It causes a ton of allocations, garbage collection, and high CPU usage, which ends up hanging the main browser thread, making the tab unresponsive and slowing down teleports.

(This is a resubmit of the PR with the line ending changes fixed).