### PR TITLE
Fixes for Tile point and intersect detection 

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -422,10 +422,7 @@ export class ActionManager {
                     let offsetPans = [];
                     let switchViews = [];
 
-                    let oldTile = {
-                        x: tile.x + (Math.abs(tile.width) / 2),
-                        y: tile.y + (Math.abs(tile.height) / 2)
-                    }
+                    const oldTile = tile.shape.center;
 
                     let tokenTransfers = {};
 
@@ -492,8 +489,7 @@ export class ActionManager {
                             let destpos = action.data.position;
 
                             if (destpos == "center") {
-                                entDest.x = dest.dest.x + (dest.dest.width / 2);
-                                entDest.y = dest.dest.y + (dest.dest.height / 2);
+                                ({x: entDest.x, y: entDest.y} = dest.dest.shape.center);
                             } else if (destpos == "relative") {
                                 let usePt = foundry.utils.duplicate(pt);
                                 if (!["enter", "exit", "click", "dblclick", "rightclick", "dblrightclick"].includes(method) && tile.pointWithin(pt))
@@ -502,37 +498,38 @@ export class ActionManager {
                                 let deltaX1 = (usePt.x - oldTile.x);
                                 let deltaY1 = (usePt.y - oldTile.y);
 
-                                let percX = deltaX1 / (Math.abs(tile.width) / 2);
-                                let percY = deltaY1 / (Math.abs(tile.height) / 2);
+                                let percX = deltaX1 / (Math.abs(tile.shape.bounds.width) / 2);
+                                let percY = deltaY1 / (Math.abs(tile.shape.bounds.height) / 2);
 
-                                let deltaX2 = (Math.abs(dest.dest.width) / 2) * percX;
-                                let deltaY2 = (Math.abs(dest.dest.height) / 2) * percY;
+                                const destBounds = dest.dest.shape.bounds;
+                                let deltaX2 = (Math.abs(destBounds.width) / 2) * percX;
+                                let deltaY2 = (Math.abs(destBounds.height) / 2) * percY;
 
                                 if (dest.dest.texture?.scaleX < 0)
                                     deltaX2 = -deltaX2;
                                 if (dest.dest.texture?.scaleY < 0)
                                     deltaY2 = -deltaY2;
 
-                                let midDestX = dest.dest.x + (Math.abs(dest.dest.width) / 2);
-                                let midDestY = dest.dest.y + (Math.abs(dest.dest.height) / 2);
-
+                                const { x: midDestX, y: midDestY } = dest.dest.shape.center;
                                 if (parseInt(midDestX + deltaX2).toNearest(dest.dest.parent.dimensions.size) == parseInt(midDestX + deltaX2) && deltaX2 > 0)
                                     deltaX2 *= 0.99;
                                 if (parseInt(midDestY + deltaY2).toNearest(dest.dest.parent.dimensions.size) == parseInt(midDestY + deltaY2) && deltaY2 > 0)
                                     deltaY2 *= 0.99;
 
-                                entDest.x = Math.clamp(parseInt(midDestX + deltaX2), dest.dest.x, dest.dest.x + dest.dest.width);
-                                entDest.y = Math.clamp(parseInt(midDestY + deltaY2), dest.dest.y, dest.dest.y + dest.dest.height);
+                                entDest.x = Math.clamp(parseInt(midDestX + deltaX2), destBounds.x, destBounds.x + destBounds.width);
+                                entDest.y = Math.clamp(parseInt(midDestY + deltaY2), destBounds.y, destBounds.y + destBounds.height);
                             } else {
                                 // Find a random location within this Tile
-                                entDest.x = dest.dest.x + Math.floor((Math.random() * Math.abs(dest.dest.width)));
-                                entDest.y = dest.dest.y + Math.floor((Math.random() * Math.abs(dest.dest.height)));
+                                const sample = dest.dest.shape.sampleInterior();
+                                entDest.x = Math.floor(sample.x);
+                                entDest.y = Math.floor(sample.y);
                             }
 
                             if (!dest.dest.pointWithin(entDest)) {
                                 // If this dest is not within the Tile, then find a random point
-                                entDest.x = dest.dest.x + Math.floor((Math.random() * Math.abs(dest.dest.width)));
-                                entDest.y = dest.dest.y + Math.floor((Math.random() * Math.abs(dest.dest.height)));
+                                const sample = dest.dest.shape.sampleInterior();
+                                entDest.x = Math.floor(sample.x);
+                                entDest.y = Math.floor(sample.y);
                             }
                         }
 
@@ -791,10 +788,7 @@ export class ActionManager {
                 fn: async (args = {}) => {
                     const { tile, tokens, action, value, pt, method } = args;
 
-                    let oldTile = {
-                        x: tile.x + (Math.abs(tile.width) / 2),
-                        y: tile.y + (Math.abs(tile.height) / 2)
-                    }
+                    const oldTile = tile.shape.center;
                     //wait for animate movement
                     let entities = await MonksActiveTiles.getEntities(args, "tokens");
 
@@ -865,8 +859,7 @@ export class ActionManager {
 
                             if (dest.dest instanceof TileDocument) {
                                 if (action.data.position == "center") {
-                                    entDest.x = dest.dest.x + (dest.dest.width / 2);
-                                    entDest.y = dest.dest.y + (dest.dest.height / 2);
+                                    ({ x: entDest.x, y: entDest.y } = dest.dest.shape.center);
                                 } else if (action.data.position == "relative") {
                                     let usePt = foundry.utils.duplicate(pt);
                                     if (!["enter", "exit", "click", "dblclick", "rightclick", "dblrightclick"].includes(method) && tile.pointWithin(pt))
@@ -875,8 +868,8 @@ export class ActionManager {
                                     let deltaX = (usePt.x - oldTile.x);
                                     let deltaY = (usePt.y - oldTile.y);
 
-                                    let destW = Math.abs(dest.dest.width);
-                                    let destH = Math.abs(dest.dest.width);
+                                    const destBounds = dest.dest.shape.bounds;
+                                    let { width: destW, height: destH } = destBounds;
 
                                     if (method == "enter" || method == "exit") {
                                         let hW = ((entity.parent.dimensions.size * Math.abs(entity.width)) / 2);
@@ -886,18 +879,19 @@ export class ActionManager {
                                         destH -= (method == "enter" ? hH : -hH);
                                     }
 
-                                    deltaX = deltaX * (destW / Math.abs(tile.width));
-                                    deltaY = deltaY * (destH / Math.abs(tile.height));
+                                    deltaX = deltaX * (destW / Math.abs(tile.shape.bounds.width));
+                                    deltaY = deltaY * (destH / Math.abs(tile.shape.bounds.height));
 
-                                    let midDestX = dest.dest.x + (Math.abs(dest.dest.width) / 2);
-                                    let midDestY = dest.dest.y + (Math.abs(dest.dest.height) / 2);
+                                    const { x: midDestX, y: midDestY } = dest.dest.shape.center;
 
-                                    entDest.x = Math.clamp(midDestX + deltaX, dest.dest.x, dest.dest.x + dest.dest.width);
-                                    entDest.y = Math.clamp(midDestY + deltaY, dest.dest.y, dest.dest.y + dest.dest.height);
+    
+                                    entDest.x = Math.clamp(midDestX + deltaX, destBounds.x, destBounds.x + destBounds.width);
+                                    entDest.y = Math.clamp(midDestY + deltaY, destBounds.y, destBounds.y + destBounds.height);
                                 } else {
                                     // Find a random location within this Tile
-                                    entDest.x = dest.dest.x + Math.floor((Math.random() * Math.abs(dest.dest.width)));
-                                    entDest.y = dest.dest.y + Math.floor((Math.random() * Math.abs(dest.dest.height)));
+                                    const sample = dest.dest.shape.sampleInterior();
+                                    entDest.x = Math.floor(sample.x);
+                                    entDest.y = Math.floor(sample.y);
                                 }
                             }
 
@@ -1324,14 +1318,14 @@ export class ActionManager {
                                                 if (entDest) {
                                                     if (dest.dest instanceof TileDocument) {
                                                         if (action.data.position == "center") {
-                                                            entDest.x = dest.dest.x + (dest.dest.width / 2);
-                                                            entDest.y = dest.dest.y + (dest.dest.height / 2);
+                                                            ({x: entDest.x, y: entDest.y} = dest.dest.shape.center);
                                                         } else {
                                                             // Find a random location within this Tile
                                                             let midX = ((canvas.scene.dimensions.size * Math.abs(entity.width ?? 1)) / 2);
                                                             let midY = ((canvas.scene.dimensions.size * Math.abs(entity.height ?? 1)) / 2);
-                                                            entDest.x = (dest.dest.x + midX) + Math.floor((Math.random() * (Math.abs(dest.dest.width) - (Math.abs(actor.prototypeToken.width) * canvas.scene.dimensions.size))));
-                                                            entDest.y = (dest.dest.y + midY) + Math.floor((Math.random() * (Math.abs(dest.dest.height) - (Math.abs(actor.prototypeToken.height) * canvas.scene.dimensions.size))));
+                                                            const bounds = dest.dest.shape.bounds();
+                                                            entDest.x = (bounds.x + midX) + Math.floor((Math.random() * (Math.abs(bounds.width) - (Math.abs(actor.prototypeToken.width) * canvas.scene.dimensions.size))));
+                                                            entDest.y = (bounds.y + midY) + Math.floor((Math.random() * (Math.abs(bounds.height) - (Math.abs(actor.prototypeToken.height) * canvas.scene.dimensions.size))));
                                                         }
                                                     }
                                                     let data = {
@@ -1395,18 +1389,17 @@ export class ActionManager {
                                 if (dest && entDest) {
                                     if (dest.dest instanceof TileDocument) {
                                         // Find a random location within this Tile
-                                        if (dest.dest instanceof TileDocument) {
-                                            if (action.data.position == "center") {
-                                                entDest.x = dest.dest.x + (dest.dest.width / 2);
-                                                entDest.y = dest.dest.y + (dest.dest.height / 2);
-                                            } else {
-                                                // Find a random location within this Tile
-                                                let midX = ((canvas.scene.dimensions.size * Math.abs(entity.prototypeToken.width)) / 2);
-                                                let midY = ((canvas.scene.dimensions.size * Math.abs(entity.prototypeToken.height)) / 2);
-                                                entDest.x = (dest.dest.x + midX) + Math.floor((Math.random() * (Math.abs(dest.dest.width) - (Math.abs(entity.prototypeToken.width) * canvas.scene.dimensions.size))));
-                                                entDest.y = (dest.dest.y + midY) + Math.floor((Math.random() * (Math.abs(dest.dest.height) - (Math.abs(entity.prototypeToken.height) * canvas.scene.dimensions.size))));
-                                            }
+                                        if (action.data.position == "center") {
+                                            ({x: entDest.x, y: entDest.y} = dest.dest.shape.center);
+                                        } else {
+                                            // Find a random location within this Tile
+                                            let midX = ((canvas.scene.dimensions.size * Math.abs(entity.prototypeToken.width)) / 2);
+                                            let midY = ((canvas.scene.dimensions.size * Math.abs(entity.prototypeToken.height)) / 2);
+                                            const bounds = dest.dest.shape.bounds();
+                                            entDest.x = (bounds.x + midX) + Math.floor((Math.random() * (Math.abs(bounds.width) - (Math.abs(entity.prototypeToken.width) * canvas.scene.dimensions.size))));
+                                            entDest.y = (bounds.y + midY) + Math.floor((Math.random() * (Math.abs(bounds.height) - (Math.abs(entity.prototypeToken.height) * canvas.scene.dimensions.size))));
                                         }
+                                        
                                     } else {
                                         if (entDest.x) {
                                             let roll = await rollDice(entDest.x);
@@ -1582,8 +1575,9 @@ export class ActionManager {
 
                                 if (dest.dest instanceof TileDocument) {
                                     // Find a random location within this Tile
-                                    dest.x = dest.dest.x + Math.floor((Math.random() * Math.abs(dest.dest.width)));
-                                    dest.y = dest.dest.y + Math.floor((Math.random() * Math.abs(dest.dest.height)));
+                                    const sample = dest.dest.shape.sampleInterior();
+                                    dest.x = Math.floor(sample.x);
+                                    dest.y = Math.floor(sample.y);
                                 } else {
                                     if (dest.x) {
                                         let roll = await rollDice(dest.x);
@@ -6972,9 +6966,8 @@ export class ActionManager {
                 group: "filters",
                 fn: async (args = {}) => {
                     const { tile, value, action } = args;
-
-                    let midTile = { x: tile.x + (Math.abs(tile.width) / 2), y: tile.y + (Math.abs(tile.height) / 2) };
-
+        
+                    let midTile = tile.shape.center;
                     let entities = await MonksActiveTiles.getEntities(args);
 
                     let tokens = entities.filter(t => {

--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -4076,76 +4076,26 @@ export class MonksActiveTiles {
     }
 
     static getTileSegments(tile, usealpha = false) {
-        let width = Math.abs(tile.width);
-        let height = Math.abs(tile.height);
-
-        let segments = [
-            { a: { x: 0, y: 0 }, b: { x: width, y: 0 } },
-            { a: { x: width, y: 0 }, b: { x: width, y: height } },
-            { a: { x: width, y: height }, b: { x: 0, y: height } },
-            { a: { x: 0, y: height }, b: { x: 0, y: 0 } }
-        ];
-
         if (usealpha) {
-            segments = [];
-            for (let i = 0; i < tile.object._textureBorderPoints.length - 2; i += 2) {
-                segments.push({ a: { x: tile.object._textureBorderPoints[i], y: tile.object._textureBorderPoints[i + 1] }, b: { x: tile.object._textureBorderPoints[i + 2], y: tile.object._textureBorderPoints[i + 3] } });
+            let segments = [];
+
+            const points = tile.object._texturePolygon.points;
+            for (let i = 0; i < points.length - 2; i += 2) {
+                segments.push({ a: { x: points[i], y: points[i + 1] }, b: { x: points[i + 2], y: points[i + 3] } });
             }
-            segments.push({ a: { x: tile.object._textureBorderPoints[tile.object._textureBorderPoints.length - 2], y: tile.object._textureBorderPoints[tile.object._textureBorderPoints.length - 1] }, b: { x: tile.object._textureBorderPoints[0], y: tile.object._textureBorderPoints[1] } })
+            segments.push({ a: { x: points[points.length - 2], y: points[points.length - 1] }, b: { x: points[0], y: points[1] } })
+
+            return segments
         } 
 
-        /*
-        if (tile.rotation != 0) {
-            function rotate(cx, cy, x, y, angle) {
-                var realangle = angle + 90,
-                    rad = Math.toRadians(realangle),
-                    sin = Math.cos(rad),
-                    cos = Math.sin(rad),
-                    run = x - cx,
-                    rise = y - cy,
-                    tx = (cos * run) + (sin * rise) + cx,
-                    ty = (cos * rise) - (sin * run) + cy;
-                return { x: tx, y: ty };
-            }
-
-            const cX = tile.x + (Math.abs(tile.width) / 2);
-            const cY = tile.y + (Math.abs(tile.height) / 2);
-
-            let pt1 = rotate(cX, cY, tileX1, tileY1, tile.rotation);
-            let pt2 = rotate(cX, cY, tileX2, tileY1, tile.rotation);
-            let pt3 = rotate(cX, cY, tileX2, tileY2, tile.rotation);
-            let pt4 = rotate(cX, cY, tileX1, tileY2, tile.rotation);
-            */
-            /*
-            let gr = MonksActiveTiles.debugGr;
-            if (!gr) {
-                gr = new PIXI.Graphics();
-                MonksActiveTiles.debugGr = gr;
-                canvas.tokens.addChild(gr);
-            }
-
-            gr.beginFill(0x00ffff)
-                .drawCircle(tileX1, tileY1, 4)
-                .drawCircle(tileX2, tileY1, 6)
-                .drawCircle(tileX2, tileY2, 8)
-                .drawCircle(tileX1, tileY2, 10)
-                .endFill();
-
-            gr.beginFill(0xffff00)
-                .drawCircle(pt1.x, pt1.y, 4)
-                .drawCircle(pt2.x, pt2.y, 6)
-                .drawCircle(pt3.x, pt3.y, 8)
-                .drawCircle(pt4.x, pt4.y, 10)
-                .endFill();
-                */
-        /*
-            segments = [
-                { a: pt1, b: pt2 },
-                { a: pt2, b: pt3 },
-                { a: pt3, b: pt4 },
-                { a: pt4, b: pt1 }
-            ];
-        }*/
+        const [polygons] = tile.shape.polygons;
+        const [x1, y1, x2, y2, x3, y3, x4, y4] = polygons.points;
+        let segments = [
+            { a: { x: x1, y: y1 }, b: { x: x2, y: y2 } },
+            { a: { x: x2, y: y2 }, b: { x: x3, y: y3 } },
+            { a: { x: x3, y: y3 }, b: { x: x4, y: y4 } },
+            { a: { x: x4, y: y4 }, b: { x: x1, y: y1 } }
+        ];
 
         return segments;
     }
@@ -4153,56 +4103,8 @@ export class MonksActiveTiles {
     static setupTile() {
         TileDocument.prototype.pointWithin = function (point) {
             let triggerData = this.flags["monks-active-tiles"];
-
-            const w = Math.abs(this.width);
-            const h = Math.abs(this.height);
-
-            // The anchor defines the pivot in local space (0–1 range)
-            const anchorX = this.texture.anchorX * w;
-            const anchorY = this.texture.anchorY * h;
-
-            // Step 1: Translate point into local tile space.
-            // this.x/y is the world position of the anchor, so offset relative to it,
-            // then shift so local space origin is the top-left corner of the tile.
-            let lx = point.x - this.x + anchorX;
-            let ly = point.y - this.y + anchorY;
-
-            // Step 2: Rotate the local point around the anchor to undo the tile's rotation.
-            if (this.rotation !== 0) {
-                const rad = Math.toRadians(-this.rotation); // negate to un-rotate
-                const cos = Math.cos(rad);
-                const sin = Math.sin(rad);
-                const dx = lx - anchorX;
-                const dy = ly - anchorY;
-                lx = cos * dx - sin * dy + anchorX;
-                ly = sin * dx + cos * dy + anchorY;
-            }
-
-            // Step 3: Undo scale around the anchor point.
-            if (triggerData?.usealpha) {
-                lx = (lx - anchorX) / this.texture.scaleX + anchorX;
-                ly = (ly - anchorY) / this.texture.scaleY + anchorY;
-
-                if (this._object && !this._object._texturePolygon)
-                    this.object._findTextureBorder();
-            }
-
-            /*
-            let gr = MonksActiveTiles.debugGr;
-            if (!gr) {
-                gr = new PIXI.Graphics();
-                MonksActiveTiles.debugGr = gr;
-                canvas.tokens.addChild(gr);
-            }
-
-            gr.lineStyle(2, 0x800080).drawCircle(lx + this.x, ly + this.y, 4);
-            */
-
-            // Step 4: Bounds check in local tile space (0,0) to (w,h).
-            if (lx < 0 || lx > w || ly < 0 || ly > h)
-                return false;
-
-            return triggerData?.usealpha && this._object?._texturePolygon ? this._object?._texturePolygon.contains(lx, ly) : true;
+            if(!triggerData?.usealpha) return this.shape.testPoint(point);
+            return this._object?._texturePolygon ? this._object?._texturePolygon.contains(point.x, point.y) : true;
         }
 
         TileDocument.prototype.tokensWithin = function () {
@@ -4569,8 +4471,8 @@ export class MonksActiveTiles {
                 sprite.anchor.set(0.5, 0.5);
                 sprite.position.set(sprite.width / 2, sprite.height / 2);
 
-                aW = this.document.width / width;
-                aH = this.document.height / height;
+                aW = 1;
+                aH = 1;
 
                 // Create or update the alphaMap render texture
                 const tex = PIXI.RenderTexture.create({ width: sprite.width, height: sprite.height });
@@ -4619,13 +4521,50 @@ export class MonksActiveTiles {
             }
 
             this._textureBorderPoints = points;
-            this._texturePolygon = new PIXI.Polygon(this._textureBorderPoints);
+            this._genTexturePolygon();
             if (CONFIG.debug.tiletriggers) {
                 if (this._debugBorder && this._debugBorder.parent)
                     this._debugBorder.destroy();
                 this._debugBorder = this.addChild(new PIXI.Graphics());
                 this._debugBorder.lineStyle(2, 0xff0000).drawPolygon(this._texturePolygon);
             }
+        }
+
+        foundry.canvas.placeables.Tile.prototype._genTexturePolygon = function () {
+            if(!this._textureBorderPoints) return;
+
+            let { x, y, rotation, width, height, texture: { scaleX, scaleY, anchorX, anchorY, src } } = this.document;
+            const dr = Math.toRadians(rotation);
+
+            let aScaleX, aScaleY;
+            if(src) {
+                const accuracy = 2;
+                aScaleX = (accuracy / (this.texture.width / width)) * scaleX;
+                aScaleY = (accuracy / (this.texture.height / height)) * scaleY;
+            }
+
+            const points = [...this._textureBorderPoints];
+            for(let i = 0; i < points.length; i +=2) {
+                // Scale
+                if(src) {
+                    points[i] *= aScaleX;
+                    points[i+1] *= aScaleY;
+                }
+
+                // Translate
+                points[i] += (x - width * anchorX * scaleX);
+                points[i+1] += (y - height * anchorY * scaleY);
+
+                // Rotation
+                if(dr !== 0) {
+                    const dx = points[i] - x;
+                    const dy = points[i+1] - y;
+                    points[i]  = x + Math.cos(dr) * dx - Math.sin(dr) * dy;
+                    points[i+1] = y + Math.sin(dr) * dx + Math.cos(dr) * dy;
+                }
+            }
+
+            this._texturePolygon = new PIXI.Polygon(points);
         }
 
         TileDocument.prototype.checkClick = function (pt, clicktype = 'click', event) {
@@ -4658,11 +4597,11 @@ export class MonksActiveTiles {
 
                 if (triggerData.usealpha && !this.object._texturePolygon)
                     this.object._findTextureBorder();
-                if (CONFIG.debug.tiletriggers && triggerData.usealpha) {
+                if (CONFIG.debug.tiletriggers) {
                     if (this.object._debugBorder)
                         this.object._debugBorder.destroy();
                     this.object._debugBorder = this.object.addChild(new PIXI.Graphics());
-                    this.object._debugBorder.lineStyle(2, 0xff0000).drawPolygon(this.object._texturePolygon);
+                    this.object._debugBorder.lineStyle(2, 0xff0000).drawPolygon(triggerData.usealpha ? this.object._texturePolygon : this.shape.polygons[0]);
                 }
 
                 /*
@@ -4699,26 +4638,12 @@ export class MonksActiveTiles {
 
             if (triggerData.usealpha && !this.object._texturePolygon)
                 this.object._findTextureBorder();
-            if (CONFIG.debug.tiletriggers && triggerData.usealpha) {
+            if (CONFIG.debug.tiletriggers) {
                 if (this.object._debugBorder)
                     this.object._debugBorder.destroy();
                 this.object._debugBorder = this.object.addChild(new PIXI.Graphics());
-                this.object._debugBorder.lineStyle(2, 0xff0000).drawPolygon(this.object._texturePolygon);
+                this.object._debugBorder.lineStyle(2, 0xff0000).drawPolygon(triggerData.usealpha ? this.object._texturePolygon : this.shape.polygons[0]);
             }
-
-            function rotate(cx, cy, x, y, angle) {
-                var rad = Math.toRadians(angle),
-                    cos = Math.cos(rad),
-                    sin = Math.sin(rad),
-                    run = x - cx,
-                    rise = y - cy,
-                    tx = (cos * run) + (sin * rise) + cx,
-                    ty = (cos * rise) - (sin * run) + cy;
-                return { x: tx, y: ty };
-            }
-
-            const cX = (Math.abs(this.width) / 2);
-            const cY = (Math.abs(this.height) / 2);
 
             const tokenOffsetW = ((token.width ?? 0) * (token?.parent?.dimensions?.size ?? 0)) / 2;
             const tokenOffsetH = ((token.height ?? 0) * (token?.parent?.dimensions?.size ?? 0)) / 2;
@@ -4727,51 +4652,12 @@ export class MonksActiveTiles {
             const tokenX2 = destination.x + tokenOffsetW;
             const tokenY2 = destination.y + tokenOffsetH;
 
-            const tokenRay = new foundry.canvas.geometry.Ray(
-                {
-                    x: tokenX1 - (this.x + cX),
-                    y: tokenY1 - (this.y + cY)
-                },
-                {
-                    x: tokenX2 - (this.x + cX),
-                    y: tokenY2 - (this.y + cY)
-                });
+            const tokenRay = new foundry.canvas.geometry.Ray({ x: tokenX1, y: tokenY1 }, { x: tokenX2, y: tokenY2 });
 
-            if (this.rotation != 0) {
-                //rotate the point
-                tokenRay.A = rotate(0, 0, tokenRay.A.x, tokenRay.A.y, this.rotation);
-                tokenRay.B = rotate(0, 0, tokenRay.B.x, tokenRay.B.y, this.rotation);
-            }
-
-            let scaleX = triggerData?.usealpha ? this.texture.scaleX : 1;
-            let scaleY = triggerData?.usealpha ? this.texture.scaleY : 1;
-
-            tokenRay.A.x = (tokenRay.A.x / scaleX) + cX;
-            tokenRay.A.y = (tokenRay.A.y / scaleY) + cY;
-            tokenRay.B.x = (tokenRay.B.x / scaleX) + cX;
-            tokenRay.B.y = (tokenRay.B.y / scaleY) + cY;
-
-            // Check the bounding box first
-            let segments = MonksActiveTiles.getTileSegments(this).filter(s => foundry.utils.lineSegmentIntersects(tokenRay.A, tokenRay.B, s.a, s.b));
-
-            if (triggerData.usealpha) {
-                //!(tokenRay.A.x <= 0 || tokenRay.A.x >= Math.abs(this.width) || tokenRay.A.y <= 0 || tokenRay.A.y >= Math.abs(this.height))
-                // only need to check the polygon if there are segments, or if both points are within the rectangle
-                if (segments.length || 
-                    !(tokenRay.A.x < 0 || tokenRay.A.x > Math.abs(this.width) || tokenRay.A.y < 0 || tokenRay.A.y > Math.abs(this.height)) || 
-                    !(tokenRay.B.x < 0 || tokenRay.B.x > Math.abs(this.width) || tokenRay.B.y < 0 || tokenRay.B.y > Math.abs(this.height))) {
-                    segments = MonksActiveTiles.getTileSegments(this, true).filter(s => foundry.utils.lineSegmentIntersects(tokenRay.A, tokenRay.B, s.a, s.b));
-                }
-            }
-
-            let intersect = segments
+            const segments = MonksActiveTiles.getTileSegments(this, triggerData.usealpha).filter(s => foundry.utils.lineSegmentIntersects(tokenRay.A, tokenRay.B, s.a, s.b));
+            const intersect = segments
                 .map(s => {
                     let point = foundry.utils.lineSegmentIntersection(tokenRay.A, tokenRay.B, s.a, s.b);
-                    let t0 = point.t0;
-                    point = { x: (point.x - cX) * scaleX, y: (point.y - cY) * scaleY }
-                    point = rotate(0, 0, point.x, point.y, this.rotation * -1);
-                    point = { x: point.x + (this.x + cX), y: point.y + (this.y + cY) }
-                    point.t0 = t0;
                     return point;
                 });
 
@@ -6326,6 +6212,8 @@ Hooks.on('updateTile', async (document, update, options, userId) => {
                 document.object._findTextureBorder();
             }, 500);
         }
+    } else if (update.x != undefined || update.y != undefined || update.rotation != undefined || update.width != undefined || update.height != undefined || update.texture != undefined) {
+        document.object._genTexturePolygon();
     }
 });
 

--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -6211,11 +6211,11 @@ Hooks.on('updateTile', async (document, update, options, userId) => {
         let triggerData = document.flags["monks-active-tiles"];
         if (triggerData?.usealpha) {
             window.setTimeout(function () {
-                document.object._findTextureBorder();
+                document.object?._findTextureBorder();
             }, 500);
         }
     } else if (update.x != undefined || update.y != undefined || update.rotation != undefined || update.width != undefined || update.height != undefined || update.texture != undefined) {
-        document.object._genTexturePolygon();
+        document.object?._genTexturePolygon();
     }
 });
 

--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -820,6 +820,18 @@ export class MonksActiveTiles {
 
                 if (dest) {
                     let found = false;
+                    if(dest instanceof foundry.documents.TileDocument) {
+                        const bounds = dest.shape.bounds;
+                        location[i] = {
+                            x: bounds.center.x,
+                            y: bounds.center.y,
+                            width: bounds.width,
+                            height: bounds.height,
+                            scene: dest.parent.id,
+                            dest: dest
+                        };
+                        found = true;
+                    }
                     /*
                     if (dest instanceof DrawingDocument) {
                         //drawing

--- a/monks-active-tiles.js
+++ b/monks-active-tiles.js
@@ -4534,22 +4534,24 @@ export class MonksActiveTiles {
             if(!this._textureBorderPoints) return;
 
             let { x, y, rotation, width, height, texture: { scaleX, scaleY, anchorX, anchorY, src } } = this.document;
+            if(!src) {
+                this._texturePolygon = new PIXI.Polygon(this.document.shape.polygons[0].points)
+                return;
+            }
+
+
             const dr = Math.toRadians(rotation);
 
-            let aScaleX, aScaleY;
-            if(src) {
-                const accuracy = 2;
-                aScaleX = (accuracy / (this.texture.width / width)) * scaleX;
-                aScaleY = (accuracy / (this.texture.height / height)) * scaleY;
-            }
+            const accuracy = 2;
+            const aScaleX = (accuracy / (this.texture.width / width)) * scaleX;
+            const aScaleY = (accuracy / (this.texture.height / height)) * scaleY;
+    
 
             const points = [...this._textureBorderPoints];
             for(let i = 0; i < points.length; i +=2) {
                 // Scale
-                if(src) {
-                    points[i] *= aScaleX;
-                    points[i+1] *= aScaleY;
-                }
+                points[i] *= aScaleX;
+                points[i+1] *= aScaleY;
 
                 // Translate
                 points[i] += (x - width * anchorX * scaleX);


### PR DESCRIPTION
#1037

Instead of mapping points and token movement rays onto local tile poly coordinates, `_texturePolygon` now represent real canvas coordinates.

`_texturePolygon` is generated within `_findTextureBorder()` and kept in-sync with the tile using the `updateTile` hook which monitors position, rotation, dimension, anchor and scale changes.

`_textureBorderPoints` is still generated once per texture src change, and is used to re-generate the `_texturePolygon` on the above mentioned tile changes.

`CONFIG.debug.tiletriggers` when set to true will now print out the exact position of the poly.

https://github.com/user-attachments/assets/3c15cb4b-5d92-4888-a410-43385163a557

